### PR TITLE
make admin console to be non blocking

### DIFF
--- a/src/buckets.rs
+++ b/src/buckets.rs
@@ -148,6 +148,19 @@ impl Buckets {
     pub fn process(&mut self) {
         metric_processor::process(self)
     }
+
+    pub fn clone(&self) -> Buckets {
+        Buckets {
+            counters: self.counters.clone(),
+            gauges: self.gauges.clone(),
+            timers: self.timers.clone(),
+            timer_data: self.timer_data.clone(),
+            bad_messages: self.bad_messages,
+            total_messages: self.total_messages,
+            last_message: self.last_message,
+            server_start_time: self.server_start_time,
+        }
+    }
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ extern crate docopt;
 
 use std::thread;
 use std::sync::mpsc::channel;
+use std::sync::{Arc, Mutex};
 use std::str;
 
 
@@ -52,6 +53,7 @@ fn main() {
     let tcp_send = event_send.clone();
 
     let mut buckets = buckets::Buckets::new();
+    let buckets_snapshot = Arc::new(Mutex::new(buckets.clone()));
 
     println!("Starting statsd - {}",
              time::at(buckets.start_time()).rfc822().to_string());
@@ -93,6 +95,9 @@ fn main() {
                     backend.flush_buckets(&buckets);
                 }
                 buckets.reset();
+
+                let snapshot = buckets.clone();
+                *buckets_snapshot.lock().unwrap() = snapshot
             }
 
             server::Event::UdpMessage(buf) => {
@@ -116,7 +121,10 @@ fn main() {
             }
 
             server::Event::TcpMessage(stream) => {
-                management::exec(stream, &mut buckets);
+                let cl_mutex = buckets_snapshot.clone();
+                thread::spawn(move || {
+                    management::exec(stream, cl_mutex);
+                });
             }
         }
     }

--- a/src/management.rs
+++ b/src/management.rs
@@ -3,23 +3,29 @@ use time;
 use std::net::TcpStream;
 use std::io::{BufReader, BufRead, Write};
 use std::fmt::Write as fmtWrite;
-
+use std::sync::{Arc, Mutex};
 
 /// Handle the management commands
 /// returning the response to send back.
-pub fn exec(stream: TcpStream, buckets: &mut Buckets) {
+pub fn exec(stream: TcpStream, buckets_mutex: Arc<Mutex<Buckets>>) {
     let mut reader = BufReader::new(stream);
     let mut done = false;
 
     while !done {
         let mut buffer = String::new();
-        let _ = reader.read_line(&mut buffer);
+        let res = reader.read_line(&mut buffer);
+        if res.is_err() {
+            done = true;
+        }
+
         let command = buffer.split_whitespace()
                             .next()
                             .unwrap_or("")
                             .to_lowercase();
         let writer = reader.get_mut();
         let mut out = String::new();
+
+        let latest_snapshot = || { (*buckets_mutex.lock().unwrap()).clone() };
 
         // Trigger Deref<Target = str>
         match &*command {
@@ -31,10 +37,10 @@ pub fn exec(stream: TcpStream, buckets: &mut Buckets) {
                 out.push_str("counters - print counter data.\n");
                 out.push_str("gauges   - print gauge data.\n");
                 out.push_str("timers   - print timer data.\n");
-                out.push_str("clear    - clear stored metrics.\n");
                 out.push_str("quit     - close this connection.\n");
             }
             "stats" => {
+                let buckets = latest_snapshot();
                 let uptime = (time::get_time() - buckets.start_time()).num_seconds();
                 write!(out, "uptime: {} seconds\n", uptime).unwrap();
                 write!(out, "bad_messages: {}\n", buckets.bad_messages()).unwrap();
@@ -42,19 +48,20 @@ pub fn exec(stream: TcpStream, buckets: &mut Buckets) {
                 write!(out, "END\n\n").unwrap();
             }
             "counters" => {
+                let buckets = latest_snapshot();
                 for (key, value) in buckets.counters().iter() {
                     write!(out, " {}: {}\n", key, value).unwrap();
                 }
                 write!(out, "END\n\n").unwrap();
             }
             "gauges" => {
-                for (key, value) in buckets.gauges().iter() {
+                for (key, value) in latest_snapshot().gauges().iter() {
                     write!(out, " {}: {}\n", key, value).unwrap();
                 }
                 write!(out, "END\n\n").unwrap();
             }
             "timers" => {
-                for (key, value) in buckets.timers().iter() {
+                for (key, value) in latest_snapshot().timers().iter() {
                     write!(out, " {}: {:?}\n", key, value).unwrap();
                 }
                 write!(out, "END\n\n").unwrap();
@@ -62,10 +69,6 @@ pub fn exec(stream: TcpStream, buckets: &mut Buckets) {
             "quit" => {
                 write!(out, "Good bye!\n\n").unwrap();
                 done = true
-            }
-            "clear" => {
-                buckets.reset();
-                write!(out, "Timers, counters and internal stats cleared.\n").unwrap();
             }
             "" => {
                 // continue.


### PR DESCRIPTION
@ljank

and tcp admin sessions handled in separate threads,
clear functionality removed as it only resets counters and timers (gauges stay same) which are done
during every flush interval anyway